### PR TITLE
Update to sylabs v1.3.1

### DIFF
--- a/client/pull.go
+++ b/client/pull.go
@@ -251,7 +251,14 @@ func (c *Client) ConcurrentDownloadImage(ctx context.Context, dst *os.File, arch
 
 	customHTTPClient := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
+			if req.Response.StatusCode == http.StatusSeeOther {
+				return http.ErrUseLastResponse
+			}
+			maxRedir := 10
+			if len(via) >= maxRedir {
+				return fmt.Errorf("stopped after %d redirects", maxRedir)
+			}
+			return nil
 		},
 	}
 

--- a/client/ref.go
+++ b/client/ref.go
@@ -93,7 +93,7 @@ func parsePath(rawPath string) (path string, tags []string, err error) {
 }
 
 // parse parses a raw Library reference, optionally taking into account ambiguity that exists
-// within Apptainer Library references.
+// within Library references.
 func parse(rawRef string, ambiguous bool) (*Ref, error) {
 	var u *url.URL
 
@@ -155,7 +155,7 @@ func Parse(rawRef string) (*Ref, error) {
 }
 
 // ParseAmbiguous behaves like Parse, but takes into account ambiguity that exists within
-// Apptainer Library references that begin with the prefix "library://".
+// Library references that begin with the prefix "library://".
 //
 // In particular, Apptainer supports hostless Library references in the form of "library://path".
 // This creates ambiguity in whether or not a host is present in the path or not. To account for

--- a/client/ref.go
+++ b/client/ref.go
@@ -92,12 +92,32 @@ func parsePath(rawPath string) (path string, tags []string, err error) {
 	return path, tags, nil
 }
 
-// Parse parses a raw Library reference.
-func Parse(rawRef string) (r *Ref, err error) {
-	u, err := url.Parse(rawRef)
-	if err != nil {
-		return nil, err
+// parse parses a raw Library reference, optionally taking into account ambiguity that exists
+// within Apptainer Library references.
+func parse(rawRef string, ambiguous bool) (*Ref, error) {
+	var u *url.URL
+
+	if ambiguous && strings.HasPrefix(rawRef, "library://") && !strings.HasPrefix(rawRef, "library:///") {
+		// Parse as if there's no host component.
+		uri, err := url.Parse(strings.Replace(rawRef, "library://", "library:///", 1))
+		if err != nil {
+			return nil, err
+		}
+
+		// If the path contains one or three parts, there was no host component. Otherwise, fall
+		// through to the normal logic.
+		if n := len(strings.Split(uri.Path[1:], "/")); n == 1 || n == 3 {
+			u = uri
+		}
 	}
+
+	if u == nil {
+		var err error
+		if u, err = url.Parse(rawRef); err != nil {
+			return nil, err
+		}
+	}
+
 	if u.Scheme != Scheme {
 		return nil, ErrRefSchemeNotValid
 	}
@@ -121,12 +141,29 @@ func Parse(rawRef string) (r *Ref, err error) {
 		return nil, err
 	}
 
-	r = &Ref{
+	r := &Ref{
 		Host: u.Host,
 		Path: path,
 		Tags: tags,
 	}
 	return r, nil
+}
+
+// Parse parses a raw Library reference.
+func Parse(rawRef string) (*Ref, error) {
+	return parse(rawRef, false)
+}
+
+// ParseAmbiguous behaves like Parse, but takes into account ambiguity that exists within
+// Apptainer Library references that begin with the prefix "library://".
+//
+// In particular, Apptainer supports hostless Library references in the form of "library://path".
+// This creates ambiguity in whether or not a host is present in the path or not. To account for
+// this, ParseAmbiguous treats library references beginning with "library://" followed by one or
+// three path components (ex. "library://a", "library://a/b/c") as hostless. All other references
+// are treated the same as Parse.
+func ParseAmbiguous(rawRef string) (*Ref, error) {
+	return parse(rawRef, true)
 }
 
 // String reassembles the ref into a valid URI string. The general form of the result is one of:

--- a/client/ref_test.go
+++ b/client/ref_test.go
@@ -170,6 +170,168 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseAmbiguous(t *testing.T) {
+	tests := []struct {
+		name            string
+		rawRef          string
+		wantErr         bool
+		wantErrSpecific error
+		wantHost        string
+		wantPath        string
+		wantTags        []string
+	}{
+		// The URI must be valid.
+		{"InvalidURL", ":", true, nil, "", "", nil},
+
+		// A path is required.
+		{"NoName", "library:", true, ErrRefPathNotValid, "", "", nil},
+		{"NoNameAndTag", "library::tag", true, ErrRefPathNotValid, "", "", nil},
+		{"NoNameAndSlash", "library:/", true, ErrRefPathNotValid, "", "", nil},
+		{"NoNameAndSlashAndTag", "library:/:tag", true, ErrRefPathNotValid, "", "", nil},
+		{"NoNameAndSlashes", "library:///", true, ErrRefPathNotValid, "", "", nil},
+		{"NoNameAndSlashesAndTag", "library:///:tag", true, ErrRefPathNotValid, "", "", nil},
+		{"NoNameAndHostSlash", "library://host/", true, ErrRefPathNotValid, "", "", nil},
+		{"NoNameAndHostSlashAndTag", "library://host/:tag", true, ErrRefPathNotValid, "", "", nil},
+		{"NoNameAndHostPortSlash", "library://host:443/", true, ErrRefPathNotValid, "", "", nil},
+		{"NoNameAndHostPortSlashAndTag", "library://host:443/:tag", true, ErrRefPathNotValid, "", "", nil},
+
+		// The scheme must be present.
+		{"NoScheme", "", true, ErrRefSchemeNotValid, "", "", nil},
+		{"NoSchemeSlash", "/", true, ErrRefSchemeNotValid, "", "", nil},
+		{"NoSchemeSlashAndTag", "/:tag", true, ErrRefSchemeNotValid, "", "", nil},
+		{"NoSchemeSlashes", "///", true, ErrRefSchemeNotValid, "", "", nil},
+		{"NoSchemeSlashesAndTag", "///:tag", true, ErrRefSchemeNotValid, "", "", nil},
+		{"NoSchemeAndHost", "//host/", true, ErrRefSchemeNotValid, "", "", nil},
+		{"NoSchemeAndHostAndTag", "//host/:tag", true, ErrRefSchemeNotValid, "", "", nil},
+		{"NoSchemeAndHostPort", "//host:443/", true, ErrRefSchemeNotValid, "", "", nil},
+		{"NoSchemeAndHostPortAndTag", "//host:443/:tag", true, ErrRefSchemeNotValid, "", "", nil},
+
+		// The scheme must be valid.
+		{"BadScheme", "bad:project", true, ErrRefSchemeNotValid, "", "", nil},
+		{"BadSchemeAndTag", "bad:project:tag", true, ErrRefSchemeNotValid, "", "", nil},
+		{"BadSchemeAndSlash", "bad:/project", true, ErrRefSchemeNotValid, "", "", nil},
+		{"BadSchemeAndSlashAndTag", "bad:/project:tag", true, ErrRefSchemeNotValid, "", "", nil},
+		{"BadSchemeAndSlashes", "bad:///project", true, ErrRefSchemeNotValid, "", "", nil},
+		{"BadSchemeAndSlashesAndTag", "bad:///project:tag", true, ErrRefSchemeNotValid, "", "", nil},
+		{"BadSchemeAndHost", "bad://host/project", true, ErrRefSchemeNotValid, "", "", nil},
+		{"BadSchemeAndHostAndTag", "bad://host/project:tag", true, ErrRefSchemeNotValid, "", "", nil},
+		{"BadSchemeAndHostPort", "bad://host:443/project", true, ErrRefSchemeNotValid, "", "", nil},
+		{"BadSchemeAndHostPortAndTag", "bad://host:443/project:tag", true, ErrRefSchemeNotValid, "", "", nil},
+
+		// User not permitted.
+		{"UserAndHost", "library://user@host/project", true, ErrRefUserNotPermitted, "", "", nil},
+		{"UserAndHostAndTag", "library://user@host/project:tag", true, ErrRefUserNotPermitted, "", "", nil},
+		{"UserAndHostPort", "library://user@host:443/project", true, ErrRefUserNotPermitted, "", "", nil},
+		{"UserAndHostPortAndTag", "library://user@host:443/project:tag", true, ErrRefUserNotPermitted, "", "", nil},
+
+		// Query not permitted.
+		{"Query", "library:project?query", true, ErrRefQueryNotPermitted, "", "", nil},
+		{"QueryAndTag", "library:project:tag?query", true, ErrRefQueryNotPermitted, "", "", nil},
+		{"QueryAndSlash", "library:/project?query", true, ErrRefQueryNotPermitted, "", "", nil},
+		{"QueryAndSlashAndTag", "library:/project:tag?query", true, ErrRefQueryNotPermitted, "", "", nil},
+		{"QueryAndSlashes", "library:///project?query", true, ErrRefQueryNotPermitted, "", "", nil},
+		{"QueryAndSlashesAndTag", "library:///project:tag?query", true, ErrRefQueryNotPermitted, "", "", nil},
+		{"QueryAndHost", "library://host/project?query", true, ErrRefQueryNotPermitted, "", "", nil},
+		{"QueryAndHostAndTag", "library://host/project:tag?query", true, ErrRefQueryNotPermitted, "", "", nil},
+		{"QueryAndHostPort", "library://host:443/project?query", true, ErrRefQueryNotPermitted, "", "", nil},
+		{"QueryAndHostPortAndTag", "library://host:443/project:tag?query", true, ErrRefQueryNotPermitted, "", "", nil},
+
+		// Fragment not permitted.
+		{"Fragment", "library:project#fragment", true, ErrRefFragmentNotPermitted, "", "", nil},
+		{"FragmentAndTag", "library:project:tag#fragment", true, ErrRefFragmentNotPermitted, "", "", nil},
+		{"FragmentAndSlash", "library:/project#fragment", true, ErrRefFragmentNotPermitted, "", "", nil},
+		{"FragmentAndSlashAndTag", "library:/project:tag#fragment", true, ErrRefFragmentNotPermitted, "", "", nil},
+		{"FragmentAndSlashes", "library:///project#fragment", true, ErrRefFragmentNotPermitted, "", "", nil},
+		{"FragmentAndSlashesAndTag", "library:///project:tag#fragment", true, ErrRefFragmentNotPermitted, "", "", nil},
+		{"FragmentAndHost", "library://host/project#fragment", true, ErrRefFragmentNotPermitted, "", "", nil},
+		{"FragmentAndHostAndTag", "library://host/project:tag#fragment", true, ErrRefFragmentNotPermitted, "", "", nil},
+		{"FragmentAndHostPort", "library://host:443/project#fragment", true, ErrRefFragmentNotPermitted, "", "", nil},
+		{"FragmentAndHostPortAndTag", "library://host:443/project:tag#fragment", true, ErrRefFragmentNotPermitted, "", "", nil},
+
+		// The URI cannot have a trailing colon without tags.
+		{"TrailingSemicolon", "library:project:", true, ErrRefTagsNotValid, "", "", nil},
+		{"TrailingSemicolonAndSlash", "library:/project:", true, ErrRefTagsNotValid, "", "", nil},
+		{"TrailingSemicolonAndSlashes", "library:///project:", true, ErrRefTagsNotValid, "", "", nil},
+		{"TrailingSemicolonAndHost", "library://host/project:", true, ErrRefTagsNotValid, "", "", nil},
+		{"TrailingSemicolonAndHostPort", "library://host:443/project:", true, ErrRefTagsNotValid, "", "", nil},
+
+		// The URI path can only have one colon to separate path/tags.
+		{"ExtraSemicolon", "library:project:tag:extra", true, ErrRefPathNotValid, "", "", nil},
+		{"ExtraSemicolonAndSlash", "library:/project:tag:extra", true, ErrRefPathNotValid, "", "", nil},
+		{"ExtraSemicolonAndSlashes", "library:///project:tag:extra", true, ErrRefPathNotValid, "", "", nil},
+		{"ExtraSemicolonAndHost", "library://host/project:tag:extra", true, ErrRefPathNotValid, "", "", nil},
+		{"ExtraSemicolonAhdHostPort", "library://host:443/project:tag:extra", true, ErrRefPathNotValid, "", "", nil},
+
+		// Test valid abbreviated paths (project).
+		{"AbbreviatedPath", "library:project", false, nil, "", "project", nil},
+		{"AbbreviatedPathAndTag", "library:project:tag", false, nil, "", "project", []string{"tag"}},
+		{"AbbreviatedPathAndSlash", "library:/project", false, nil, "", "project", nil},
+		{"AbbreviatedPathAndSlashAndTag", "library:/project:tag", false, nil, "", "project", []string{"tag"}},
+		{"AbbreviatedPathAndSlashes", "library:///project", false, nil, "", "project", nil},
+		{"AbbreviatedPathAndSlashesAndTag", "library:///project:tag", false, nil, "", "project", []string{"tag"}},
+		{"AbbreviatedPathHostless", "library://project", false, nil, "", "project", nil},
+		{"AbbreviatedPathHostlessAndTag", "library://project:tag", false, nil, "", "project", []string{"tag"}},
+		{"AbbreviatedPathAndHost", "library://host/project", false, nil, "host", "project", nil},
+		{"AbbreviatedPathAndHostAndTag", "library://host/project:tag", false, nil, "host", "project", []string{"tag"}},
+		{"AbbreviatedPathAndHostPort", "library://host:443/project", false, nil, "host:443", "project", nil},
+		{"AbbreviatedPathAndHostPortAndTag", "library://host:443/project:tag", false, nil, "host:443", "project", []string{"tag"}},
+
+		// Test valid paths (entity/collection/container).
+		{"LegacyPath", "library:entity/collection/container", false, nil, "", "entity/collection/container", nil},
+		{"LegacyPathAndTag", "library:entity/collection/container:tag", false, nil, "", "entity/collection/container", []string{"tag"}},
+		{"LegacyPathAndSlash", "library:/entity/collection/container", false, nil, "", "entity/collection/container", nil},
+		{"LegacyPathAndSlashAndTag", "library:/entity/collection/container:tag", false, nil, "", "entity/collection/container", []string{"tag"}},
+		{"LegacyPathAndSlashes", "library:///entity/collection/container", false, nil, "", "entity/collection/container", nil},
+		{"LegacyPathAndSlashesAndTag", "library:///entity/collection/container:tag", false, nil, "", "entity/collection/container", []string{"tag"}},
+		{"LegacyPathHostless", "library://entity/collection/container", false, nil, "", "entity/collection/container", nil},
+		{"LegacyPathHostlessAndTag", "library://entity/collection/container:tag", false, nil, "", "entity/collection/container", []string{"tag"}},
+		{"LegacyPathAndHost", "library://host/entity/collection/container", false, nil, "host", "entity/collection/container", nil},
+		{"LegacyPathAndHostAndTag", "library://host/entity/collection/container:tag", false, nil, "host", "entity/collection/container", []string{"tag"}},
+		{"LegacyPathAndHostPort", "library://host:443/entity/collection/container", false, nil, "host:443", "entity/collection/container", nil},
+		{"LegacyPathAndHostPortAndTag", "library://host:443/entity/collection/container:tag", false, nil, "host:443", "entity/collection/container", []string{"tag"}},
+
+		// Test with a different number of tags.
+		{"TagsNone", "library:project", false, nil, "", "project", nil},
+		{"TagsOne", "library:project:tag1", false, nil, "", "project", []string{"tag1"}},
+		{"TagsTwo", "library:project:tag1,tag2", false, nil, "", "project", []string{"tag1", "tag2"}},
+		{"TagsThree", "library:project:tag1,tag2,tag3", false, nil, "", "project", []string{"tag1", "tag2", "tag3"}},
+
+		// Test with IP addresses.
+		{"IPv4Host", "library://127.0.0.1/project", false, nil, "127.0.0.1", "project", nil},
+		{"IPv4HostPort", "library://127.0.0.1:443/project", false, nil, "127.0.0.1:443", "project", nil},
+		{"IPv6Host", "library://[fe80::1ff:fe23:4567:890a]/project", false, nil, "[fe80::1ff:fe23:4567:890a]", "project", nil},
+		{"IPv6HostPort", "library://[fe80::1ff:fe23:4567:890a]:443/project", false, nil, "[fe80::1ff:fe23:4567:890a]:443", "project", nil},
+		{"IPv6HostZone", "library://[fe80::1ff:fe23:4567:890a%25eth1]/project", false, nil, "[fe80::1ff:fe23:4567:890a%eth1]", "project", nil},
+		{"IPv6HostZonePort", "library://[fe80::1ff:fe23:4567:890a%25eth1]:443/project", false, nil, "[fe80::1ff:fe23:4567:890a%eth1]:443", "project", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := ParseAmbiguous(tt.rawRef)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("got err %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErrSpecific != nil {
+				if got, want := err, tt.wantErrSpecific; got != want {
+					t.Fatalf("got err %v, want %v", got, want)
+				}
+			}
+
+			if err == nil {
+				if got, want := r.Host, tt.wantHost; got != want {
+					t.Errorf("got host %v, want %v", got, want)
+				}
+				if got, want := r.Path, tt.wantPath; got != want {
+					t.Errorf("got path %v, want %v", got, want)
+				}
+				if got, want := r.Tags, tt.wantTags; !reflect.DeepEqual(got, want) {
+					t.Errorf("got tags %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}
+
 func TestString(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
This pulls in the following PRs from sylabs/scs-client-library, syncing up to their version v1.3.1:
- sylabs/scs-library-client#139
- sylabs/scs-library-client#140