### PR TITLE
Update to sylabs v1.4.2

### DIFF
--- a/client/pull.go
+++ b/client/pull.go
@@ -236,13 +236,28 @@ func (c *Client) legacyDownloadImage(ctx context.Context, arch, name, tag string
 		return err
 	}
 
+	redirectURL, err := url.Parse(res.Header.Get("Location"))
+	if err != nil {
+		return err
+	}
+
 	var creds credentials
-	if c.AuthToken != "" {
+	if c.AuthToken != "" && samehost(c.BaseURL, redirectURL) {
+		// Only include credentials if redirected to same host as base URL
 		creds = bearerTokenCredentials{authToken: c.AuthToken}
 	}
 
-	// Use uri from Location header to download artifact
-	return c.multipartDownload(ctx, res.Header.Get("Location"), creds, dst, img.Size, spec, pb)
+	// Use redirect URL to download artifact
+	return c.multipartDownload(ctx, redirectURL.String(), creds, dst, img.Size, spec, pb)
+}
+
+// samehost returns true if host1 and host2 are, in fact, the same host by
+// comparing scheme (https == https) and host, including port.
+//
+// Hosts will be treated as dissimilar if one host includes domain suffix
+// and the other does not, even if the host names match.
+func samehost(host1, host2 *url.URL) bool {
+	return strings.EqualFold(host1.Scheme, host2.Scheme) && strings.EqualFold(host1.Host, host2.Host)
 }
 
 func parseContentLengthHeader(val string) (int64, error) {


### PR DESCRIPTION
This pulls in the following PR from sylabs/scs-client-library, syncing up to their version v1.4.2:
- GHSA-7p8m-22h4-9pj7