### PR TITLE
Update to sylabs v1.4.5

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,9 @@ import (
 
 	"github.com/go-log/log"
 )
+
+// ErrUnauthorized represents HTTP status "401 Unauthorized"
+var ErrUnauthorized = errors.New("unauthorized")
 
 // Config contains the client configuration.
 type Config struct {

--- a/client/oci.go
+++ b/client/oci.go
@@ -440,7 +440,11 @@ func (r *ociRegistry) doRequestWithCredentials(req *http.Request, creds credenti
 	if code := res.StatusCode; code/100 != 2 {
 		defer res.Body.Close()
 
-		return nil, fmt.Errorf("unexpected HTTP status %v", res.StatusCode)
+		if code == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
+		}
+
+		return nil, fmt.Errorf("unexpected http status %v", res.StatusCode)
 	}
 
 	return res, nil
@@ -483,6 +487,10 @@ func (r *ociRegistry) doRequest(req *http.Request, creds credentials, opts ...mo
 
 			opts = append(opts, withAuthenticateHeader(res.Header.Get("WWW-Authenticate")))
 			return r.retryRequestWithCredentials(req, creds, opts...)
+		}
+
+		if code == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
 		}
 
 		return nil, fmt.Errorf("unexpected http status %v", code)

--- a/client/oci.go
+++ b/client/oci.go
@@ -36,6 +36,10 @@ func (c *Client) ociRegistryAuth(ctx context.Context, name string, accessTypes [
 	v := url.Values{}
 	v.Set("namespace", name)
 
+	// Setting 'mapped' to '1' (true) enables support for mapping short library refs to
+	// fully-qualified name
+	v.Set("mapped", strconv.Itoa(1))
+
 	ats := make([]string, 0, len(accessTypes))
 	for _, at := range accessTypes {
 		ats = append(ats, string(at))

--- a/client/oci.go
+++ b/client/oci.go
@@ -625,6 +625,7 @@ func (r *ociRegistry) getImageConfig(ctx context.Context, creds credentials, nam
 
 var errOCIDownloadNotSupported = errors.New("not supported")
 
+// newOCIRegistry returns *ociRegistry, credentials for that registry, and the (optionally) remapped image name
 func (c *Client) newOCIRegistry(ctx context.Context, name string, accessTypes []accessType) (*ociRegistry, *bearerTokenCredentials, error) {
 	// Attempt to obtain (direct) OCI registry auth token
 	registryURI, creds, err := c.ociRegistryAuth(ctx, name, accessTypes)

--- a/client/pull.go
+++ b/client/pull.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -62,6 +62,9 @@ func (c *Client) DownloadImage(ctx context.Context, w io.Writer, arch, path, tag
 		err := jsonresp.ReadError(res.Body)
 		if err != nil {
 			return fmt.Errorf("download did not succeed: %v", err)
+		}
+		if res.StatusCode == http.StatusUnauthorized {
+			return ErrUnauthorized
 		}
 		return fmt.Errorf("unexpected http status code: %d", res.StatusCode)
 	}
@@ -228,7 +231,10 @@ func (c *Client) legacyDownloadImage(ctx context.Context, arch, name, tag string
 	}
 
 	if res.StatusCode != http.StatusSeeOther {
-		return fmt.Errorf("unexpected HTTP status %d: %v", res.StatusCode, err)
+		if res.StatusCode == http.StatusUnauthorized {
+			return ErrUnauthorized
+		}
+		return fmt.Errorf("unexpected http status %d", res.StatusCode)
 	}
 
 	// Get image metadata to determine image size

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -212,7 +212,7 @@ func seedRandomNumberGenerator(t *testing.T) {
 	if _, err := crypto_rand.Read(b[:]); err != nil {
 		t.Fatalf("error seeding random number generator: %v", err)
 	}
-	math_rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
+	math_rand.New(math_rand.NewSource(int64(binary.LittleEndian.Uint64(b[:]))))
 }
 
 // mockLibraryServer returns *httptest.Server that mocks Cloud Library server; in particular,


### PR DESCRIPTION
This pulls in the following PR from sylabs/scs-client-library, syncing up to their version v1.4.5:
- sylabs/scs-client-library# 165
- sylabs/scs-client-library# 164
which fixed
- sylabs/scs-client-library# 155